### PR TITLE
fixes #17 with a test

### DIFF
--- a/src/app/Editor.js
+++ b/src/app/Editor.js
@@ -472,16 +472,14 @@ define([
                 console.log(this.declaredClass + "::undo", arguments);
 
                 if (!this.undoManager.canUndo) {
-                    //disable undo
-                    domClass.add(this.undoNode, 'disabled');
                     console.log('nothing to undo');
+
                     return;
                 }
 
-                //undo redo don't return promise. can't shot activity
+                //undo redo don't return promise. can't show activity
                 //topic.publish('map-activity', 1);
 
-                domClass.remove(this.redoNode, 'disabled');
                 this.undoManager.undo();
                 this.updateUndoRedoCounts();
             },
@@ -492,8 +490,8 @@ define([
                 console.log(this.declaredClass + "::redo", arguments);
 
                 if (!this.undoManager.canRedo) {
-                    //disable redo
                     console.log('nothing to redo');
+
                     return;
                 }
 
@@ -512,8 +510,19 @@ define([
                 var len = this.undoManager.length;
                 var undo = (position === 0) ? '' : position;
                 var redo = (len - position === 0) ? '' : len - position;
+
                 this.set('undoCount', undo);
                 this.set('redoCount', redo);
+
+                if (this.get('undoCount') < 1) {
+                    domClass.add(this.undoNode, 'disabled');
+                    domClass.remove(this.redoNode, 'disabled');
+                }
+                else
+                {
+                    domClass.add(this.redoNode, 'disabled');
+                    domClass.remove(this.undoNode, 'disabled');
+                }
             }
         });
     });

--- a/src/app/tests/spec/SpecEditor.js
+++ b/src/app/tests/spec/SpecEditor.js
@@ -1,112 +1,142 @@
 define([
-    'intern!object',
+        'intern!object',
 
-    'intern/chai!assert',
-    
-    'dojo/_base/window',
+        'intern/chai!assert',
 
-    'dojo/dom-construct',
-    'dojo/dom-class',
+        'dojo/_base/window',
 
-    'app/Editor'
+        'dojo/dom-construct',
+        'dojo/dom-class',
 
-],
+        'app/Editor'
 
-function (
-    registerSuite,
-    assert,
-    win,
-    domConstruct,
-    domClass,
-    Editor
+    ],
+
+    function(
+        registerSuite,
+        assert,
+        win,
+        domConstruct,
+        domClass,
+        Editor
     ) {
-    var testWidget;
-    var mockMap = {
-        loaded: true
-    };
-
-    registerSuite({
-        name: 'app/Editor',
-
-        beforeEach: function () {
-            testWidget = new Editor({
-                map: mockMap
-            }, domConstruct.create('div', {}, win.body()));
-        },
-        afterEach: function () {
-            testWidget.destroy();
-            testWidget = null;
-        },
-
-        'creates_a_valid_object': function () {
-            assert.equal(testWidget.declaredClass, 'app.editor');
-        },
-
-        'addUndoState': {
-            'enables undo button': function () {
-                testWidget.addUndoState([1,2,3]);
-
-                assert.isFalse(domClass.contains(testWidget.undoNode, 'disabled'));
+        var testWidget;
+        var mockMap = {
+            loaded: true
+        };
+        var mockFeaturelayer = {
+            applyEdits: function(){
+                return true;
             }
-        },
-        'undo': {
-            'disables undo button if there are no more operations to undo': function () {
-                domClass.remove(testWidget.undoNode, 'disabled');
-                testWidget.undoManager.canUndo = true;
+        };
+        var mockGraphic = {
+            setGeometry: function()
+            {
+                return true;
+            },
+            setAttributes: function(){
+                return true;
+            },
+            geometry: {
+                toJson: function() {
+                    return "";
+                }
+            }
+        };
+
+        registerSuite({
+            name: 'app/Editor',
+
+            beforeEach: function() {
+                testWidget = new Editor({
+                    map: mockMap,
+                    editLayer: mockFeaturelayer
+                }, domConstruct.create('div', {}, win.body()));
+            },
+            afterEach: function() {
+                testWidget.destroy();
+                testWidget = null;
+            },
+
+            'creates_a_valid_object': function() {
+                assert.equal(testWidget.declaredClass, 'app.editor');
+            },
+
+            'bug_17': function() {
+                //operationType, graphic, original
+                testWidget.addUndoState("update", mockGraphic, mockGraphic);
 
                 testWidget.undo();
-
-                assert.isFalse(domClass.contains(testWidget.undoNode, 'disabled'));
-
-                testWidget.undoManager.canUndo = false;
                 testWidget.undo();
 
-                assert.isTrue(domClass.contains(testWidget.undoNode, 'disabled'));
+                assert.isTrue(domClass.contains(testWidget.undoNode, 'disabled'), "expecting disabled to still be there and it's not");
             },
-            'enables redo button': function () {
-                domClass.add(testWidget.undoNode, 'disabled');
 
-                testWidget.undo();
+            'addUndoState': {
+                'enables undo button': function() {
+                    testWidget.addUndoState("update", mockGraphic, mockGraphic);
 
-                assert.isFalse(domClass.contains(testWidget.redoNode, 'disabled'));
+                    assert.isFalse(domClass.contains(testWidget.undoNode, 'disabled'));
+                }
+            },
+            'undo': {
+                'disables undo button if there are no more operations to undo': function() {
+                    domClass.remove(testWidget.undoNode, 'disabled');
+                    testWidget.undoManager.canUndo = true;
+
+                    testWidget.undo();
+
+                    assert.isTrue(domClass.contains(testWidget.undoNode, 'disabled'));
+
+                    testWidget.undoManager.canUndo = false;
+                    testWidget.undo();
+
+                    assert.isTrue(domClass.contains(testWidget.undoNode, 'disabled'));
+                },
+                'enables redo button': function() {
+                    domClass.add(testWidget.undoNode, 'disabled');
+
+                    testWidget.undo();
+
+                    assert.isFalse(domClass.contains(testWidget.redoNode, 'disabled'));
+                }
+            },
+            'updateUndoRedoCounts': {
+                'shows correct counts when there is no available undos': function() {
+                    testWidget.undoManager.length = 0;
+
+                    testWidget.updateUndoRedoCounts();
+
+                    assert.strictEqual(testWidget.undoCount, '');
+                    assert.strictEqual(testWidget.redoCount, '');
+                },
+                'shows the correct counts when there are 3 undos but none have been undone': function() {
+                    testWidget.undoManager.length = 3;
+                    testWidget.undoManager.position = 3;
+
+                    testWidget.updateUndoRedoCounts();
+
+                    assert.strictEqual(testWidget.undoCount, 3);
+                    assert.strictEqual(testWidget.redoCount, '');
+                },
+                'shows the correct counts when there are 3 undos and 2 have been undone': function() {
+                    testWidget.undoManager.length = 3;
+                    testWidget.undoManager.position = 1;
+
+                    testWidget.updateUndoRedoCounts();
+
+                    assert.strictEqual(testWidget.undoCount, 1);
+                    assert.strictEqual(testWidget.redoCount, 2);
+                },
+                'shows the correct counts when there are 3 undos and 3 have been undone': function() {
+                    testWidget.undoManager.length = 3;
+                    testWidget.undoManager.position = 0;
+
+                    testWidget.updateUndoRedoCounts();
+
+                    assert.strictEqual(testWidget.undoCount, '');
+                    assert.strictEqual(testWidget.redoCount, 3);
+                }
             }
-        },
-        'updateUndoRedoCounts': {
-            'shows correct counts when there is no available undos': function () {
-                testWidget.undoManager.length = 0;
-
-                testWidget.updateUndoRedoCounts();
-
-                assert.strictEqual(testWidget.undoCount, '');
-                assert.strictEqual(testWidget.redoCount, '');
-            },
-            'shows the correct counts when there are 3 undos but none have been undone': function () {
-                testWidget.undoManager.length = 3;
-                testWidget.undoManager.position = 3;
-
-                testWidget.updateUndoRedoCounts();
-
-                assert.strictEqual(testWidget.undoCount, 3);
-                assert.strictEqual(testWidget.redoCount, '');
-            },
-            'shows the correct counts when there are 3 undos and 2 have been undone': function () {
-                testWidget.undoManager.length = 3;
-                testWidget.undoManager.position = 1;
-
-                testWidget.updateUndoRedoCounts();
-
-                assert.strictEqual(testWidget.undoCount, 1);
-                assert.strictEqual(testWidget.redoCount, 2);
-            },
-            'shows the correct counts when there are 3 undos and 3 have been undone': function () {
-                testWidget.undoManager.length = 3;
-                testWidget.undoManager.position = 0;
-
-                testWidget.updateUndoRedoCounts();
-
-                assert.strictEqual(testWidget.undoCount, '');
-                assert.strictEqual(testWidget.redoCount, 3);
-            }
-        }
+        });
     });
-});


### PR DESCRIPTION
moved all the enable/disable logic into the one method. This keeps the fragmentation down. Also it only depends on the values in the undo redo count variables which I trust to be accurate.
